### PR TITLE
Remove require rubygems in the gemspec

### DIFF
--- a/win32-process.gemspec
+++ b/win32-process.gemspec
@@ -1,5 +1,3 @@
-require 'rubygems'
-
 Gem::Specification.new do |spec|
   spec.name       = 'win32-process'
   spec.version    = '0.8.3'


### PR DESCRIPTION
There's no need for this in modern ruby

Signed-off-by: Tim Smith <tsmith@chef.io>