### PR TITLE
Remove support for the $SAFE variable

### DIFF
--- a/lib/win32/process.rb
+++ b/lib/win32/process.rb
@@ -741,8 +741,6 @@ module Process
     #   Process.kill(1, 12345, :exit_proc => 'ExitProcess', :module => 'kernel32')
     #
     def kill(signal, *pids)
-      raise SecurityError if $SAFE && $SAFE >= 2 # Match the spec
-
       # Match the spec, require at least 2 arguments
       if pids.length == 0
         raise ArgumentError, "wrong number of arguments (1 for at least 2)"

--- a/test/test_win32_process_kill.rb
+++ b/test/test_win32_process_kill.rb
@@ -116,28 +116,6 @@ class TC_Win32_Process_Kill < Test::Unit::TestCase
   #  assert_raise(Errno::EPERM){ Process.kill(9, 1) }
   #end
 
-  test "kill raises a SecurityError if $SAFE level is 2 or greater" do
-    omit_if(@ruby == 'jruby')
-    assert_raise(SecurityError){
-      proc do
-        $SAFE = 2
-        @pid = Process.spawn(@cmd)
-        Process.kill(9, @pid)
-      end.call
-    }
-  end
-
-  test "kill works if the $SAFE level is 1 or lower" do
-    omit_if(@ruby == 'jruby')
-    assert_nothing_raised{
-      proc do
-        $SAFE = 1
-        @pid = Process.spawn(@cmd)
-        Process.kill(9, @pid)
-      end.call
-    }
-  end
-
 =begin
   test "kill(0) can't tell if the process ended, use get_exitcode instead" do
     pid = Process.create(


### PR DESCRIPTION
This feature is being removed from Ruby 3.0 and is not a suggested thing for users to do. It causes warning messages in Ruby 2.7+

Signed-off-by: Tim Smith <tsmith@chef.io>